### PR TITLE
Only override aws creds when given

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    better_sqs (0.1.1.dev1)
+    better_sqs (0.1.1)
       aws-sdk (~> 2)
       lincoln_logger (~> 1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    better_sqs (0.1.0.dev7)
+    better_sqs (0.1.1.dev1)
       aws-sdk (~> 2)
       lincoln_logger (~> 1.0)
 

--- a/better_sqs.gemspec
+++ b/better_sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "better_sqs"
-  s.version     = "0.1.1.dev1"
+  s.version     = "0.1.1"
   s.license     = "MIT"
   s.date        = "2016-02-24"
   s.summary     = "A more idiomatic interface to SQS."

--- a/better_sqs.gemspec
+++ b/better_sqs.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name        = "better_sqs"
-  s.version     = "0.1.0"
+  s.version     = "0.1.1.dev1"
   s.license     = "MIT"
-  s.date        = "2016-01-26"
+  s.date        = "2016-02-24"
   s.summary     = "A more idiomatic interface to SQS."
   s.description = "A convenient API for developers to interact with SQS with a trivial amount of effort"
   s.authors     = ["Courtland Caldwell"]

--- a/lib/better_sqs/configuration.rb
+++ b/lib/better_sqs/configuration.rb
@@ -11,14 +11,21 @@ module BetterSqs
       @sqs_message_deferral_seconds = 60
       @aws_access_key_id      = ENV["AWS_ACCESS_KEY_ID"]
       @aws_secret_access_key  = ENV["AWS_SECRET_ACCESS_KEY"]
-      @region                 = ENV["AWS_REGION"]
+      @region                 = ENV["AWS_REGION"] || "us-east-1"
     end
 
     def configure_aws
+      return configure_region_only unless aws_secret_access_key && aws_access_key_id
       Aws.config.update(
         region:      region,
         credentials: Aws::Credentials.new(aws_access_key_id, aws_secret_access_key),
       )
+    end
+
+    private
+
+    def configure_region_only
+      Aws.config.update(region: region)
     end
   end
 end


### PR DESCRIPTION
This allows aws sqs to use metadata service derived credentials natively when they are not explicitly specified and when running on an host with a designated iam role.
